### PR TITLE
Use `apk add --no-cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM alpine
 
-RUN apk add --update ca-certificates \
+RUN apk add --no-cache ca-certificates \
     && apk add --update -t deps curl \
     && curl https://storage.googleapis.com/kubernetes-release/release/v1.4.7/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl \
-    && rm /var/cache/apk/*
+    && chmod +x /usr/local/bin/kubectl
 
 ENTRYPOINT ["kubectl"]


### PR DESCRIPTION
See https://github.com/giantswarm/cert-operator/pull/46, and https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache for the original reference.