### PR TITLE
Update to kubernetes 1.15.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk add --no-cache ca-certificates \
     && apk add --update -t deps curl \
-    && curl https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && curl https://storage.googleapis.com/kubernetes-release/release/v1.15.5/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
 ENTRYPOINT ["kubectl"]


### PR DESCRIPTION
`calico-kube-kill` on KVM master node is not working due to: `Nov 18 13:42:41 master-r08q2-69447fc4d7-x4z2r sh[9464]: error: the server doesn't have a resource type "cs"`. I believe this is due to a version mismatch between this kubectl (1.10.3) and the server's version (1.15.5) so I'm updating the version to match.