### PR TITLE
rollback-root-user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,5 @@ RUN apk add --no-cache ca-certificates \
     && curl https://storage.googleapis.com/kubernetes-release/release/v1.16.4/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
-RUN adduser -u 1010 -D nouser
-USER 1010
-
 ENTRYPOINT ["kubectl"]
 


### PR DESCRIPTION
use root, because the k8s-addons is using this and in order to read the certificates we need root user