### PR TITLE
Add giantswarm user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update `kubectl` to version `1.18.8`. ([#26](https://github.com/giantswarm/docker-kubectl/pull/26))
+- Update base image to Alpine `3.12`. ([#26](https://github.com/giantswarm/docker-kubectl/pull/26))
+
+### Added
+
+- `giantswarm` user as default user. ([#26](https://github.com/giantswarm/docker-kubectl/pull/26))
+
 ## [1.18.2] - 2020-06-30
 
 ## Added
 
 - Add `kubectl` version `1.18.2` .
-
 
 [Unreleased]: https://github.com/giantswarm/docker-kubectl/compare/v1.18.2...HEAD
 [1.18.2]: https://github.com/giantswarm/docker-kubectl/compare/v1.16.4...v1.18.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ RUN apk add --no-cache ca-certificates \
     && curl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
+RUN adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm
+USER giantswarm
+
 ENTRYPOINT ["kubectl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/giantswarm/alpine:3.12
 
-ARG VERSION=v1.18.2
+ARG VERSION=v1.18.8
 RUN apk add --no-cache ca-certificates \
     && apk add --update -t deps curl \
     && curl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,5 @@ RUN apk add --no-cache ca-certificates \
     && chmod +x /usr/local/bin/kubectl
 
 RUN adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm
-USER giantswarm
 
 ENTRYPOINT ["kubectl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/alpine:3.11
+FROM quay.io/giantswarm/alpine:3.12
 
 ARG VERSION=v1.18.2
 RUN apk add --no-cache ca-certificates \


### PR DESCRIPTION
This PR is mostly for adding a user to the image. This is because if we just use a random UID in a k8s yaml then we have no home directory to write to:

```
/ $ whoami
whoami: unknown uid 1000
/ $ echo $HOME
/
```

```
I0818 13:47:22.824167     732 request.go:621] Throttling request took 1.197509724s, request: GET:https://10.96.0.1:443/apis/admissionregistration.k8s.io/v1?timeout=32s
I0818 13:47:33.024118     732 request.go:621] Throttling request took 4.398697453s, request: GET:https://10.96.0.1:443/apis/authentication.k8s.io/v1?timeout=32s

I0818 13:41:13.317726     483 cached_discovery.go:87] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/extensions/v1beta1/serverresources.json due to mkdir /.kube: permission denied
I0818 13:41:13.317786     483 cached_discovery.go:87] failed to write cache to /.kube/cache/discovery/10.96.0.1_443/admissionregistration.k8s.io/v1/serverresources.json due to mkdir /.kube: permission denied
```

This causes a lot of extra API calls which results in the apiserver throttling us and could potentially cause unexpected failures.