### PR TITLE
Update to alpine 3.16 and install jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM quay.io/giantswarm/alpine:3.12
+FROM quay.io/giantswarm/alpine:3.16
 
 ARG VERSION=v1.24.1
-RUN apk add --no-cache ca-certificates \
-    && apk add --update -t deps curl \
+RUN apk add --no-cache ca-certificates curl jq \
     && curl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
This PR:

- Updates the base image to alpine:3.16
- Additionally installs `jq` from alpine repositories. We need it to patch cert-manager crds in the helm install job

Requesting additional review from @AverageMarcus as you seem to care about this repo ;)