### PR TITLE
Do not merge - Add cmctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/giantswarm/alpine:3.16
 ARG VERSION=v1.24.2
 RUN apk add --no-cache ca-certificates curl jq \
     && curl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && curl -L https://github.com/cert-manager/cert-manager/releases/download/v1.7.3/cmctl-linux-amd64.tar.gz | tar xvz -C /usr/local/bin cmctl \
     && chmod +x /usr/local/bin/kubectl
 
 RUN adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm


### PR DESCRIPTION
This PR should not be merged. It is here to document the changes done to the Dockerfile for the changed container image to solve https://github.com/giantswarm/giantswarm/issues/22730

The container image tag `1.24.2-gs-issue-22730` was prepared from container image tag `1.24.2-ef801a896ca1a9e11e7760e95d8edffd3c790a66`. I'll make the `cmctl` cli tool available for the cert-manager-app CRD install Job.

```
docker pull quay.io/giantswarm/docker-kubectl:1.24.2-ef801a896ca1a9e11e7760e95d8edffd3c790a66
docker tag quay.io/giantswarm/docker-kubectl:1.24.2-ef801a896ca1a9e11e7760e95d8edffd3c790a66 quay.io/giantswarm/docker-kubectl:1.24.2-gs-issue-22730
docker push quay.io/giantswarm/docker-kubectl:1.24.2-gs-issue-22730
```