### PR TITLE
Build multi-arch (amd64 + arm64) container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.12.0
+  architect: giantswarm/architect@8.0.2
 
 workflows:
   build:
@@ -9,6 +9,7 @@ workflows:
       - architect/push-to-registries:
           context: architect
           name: push-to-registries
+          multiarch: true
           filters:
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. Required so init containers and jobs that pull this image can run on Graviton/arm64 nodes without `exec format error`. The `kubectl` binary is now downloaded from `linux/${TARGETARCH}/kubectl` based on the build platform.
+
 ## [1.36.0] - 2026-04-29
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM gsoci.azurecr.io/giantswarm/alpine:3.22.1
-
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/alpine:3.22.1 AS prep
+USER root
 ARG VERSION=v1.36.0
 ARG TARGETARCH
 RUN apk add --no-cache ca-certificates curl jq \
-    && curl --silent --show-error --fail --location https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl --output /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+    && curl --silent --show-error --fail --location https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl --output /kubectl \
+    && chmod +x /kubectl \
+    && adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm
 
-RUN adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm
+FROM gsoci.azurecr.io/giantswarm/alpine:3.22.1
+
+COPY --from=prep /kubectl /usr/local/bin/kubectl
+COPY --from=prep /etc/ssl/certs /etc/ssl/certs
+COPY --from=prep /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=prep /usr/bin/jq /usr/bin/jq
+COPY --from=prep /etc/passwd /etc/passwd
+COPY --from=prep /etc/group /etc/group
+COPY --from=prep /etc/shadow /etc/shadow
+COPY --from=prep --chown=1000:1000 /home/giantswarm /home/giantswarm
 
 ENTRYPOINT ["kubectl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM gsoci.azurecr.io/giantswarm/alpine:3.22.1
 
 ARG VERSION=v1.36.0
+ARG TARGETARCH
 RUN apk add --no-cache ca-certificates curl jq \
-    && curl --silent --show-error --fail --location https://dl.k8s.io/release/${VERSION}/bin/linux/amd64/kubectl --output /usr/local/bin/kubectl \
+    && curl --silent --show-error --fail --location https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl --output /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
 RUN adduser -h "/home/giantswarm" -s /bin/sh -u 1000 -D giantswarm giantswarm


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35827

Builds and publishes the docker-kubectl image for both `linux/amd64` and `linux/arm64`. Today the image is amd64-only — it hardcodes the `linux/amd64` path in the kubectl download URL — so any pod using it as an init container (e.g. `net-exporter`'s `label-kube-system-namespace` init) fails on Graviton/arm64 nodes with `exec /usr/local/bin/kubectl: exec format error`.

Pattern aligned with [`giantswarm/architect`](https://github.com/giantswarm/architect/blob/master/.circleci/config.yml):

- Bump architect orb to `v8.0.2` (current pin `v6.12.0` predates the `multiarch` parameter).
- `architect/push-to-registries` set to `multiarch: true`. `platforms` defaults to `linux/amd64,linux/arm64`.
- Dockerfile uses `ARG TARGETARCH` (set per-platform by `docker buildx`) to pull the matching kubectl binary from `https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl`.

Verified failure on graveler-nick: `net-exporter-n9n84` on arm64 m7g.xlarge node, init container `label-kube-system-namespace` (image `gsoci.azurecr.io/giantswarm/docker-kubectl:1.25.4`) in CrashLoopBackOff with `exec format error`. After this lands and a release is cut, init containers using this image will run cleanly on arm64.
