### PR TITLE
Revert v1.37.0 CHANGELOG entry; record multi-arch as in-place rebuild of v1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. The `v1.36.0` registry tag was rebuilt in-place to include both architectures (kubectl version unchanged), so existing consumers pinning `1.36.0` automatically get arm64 support on next pull. The convention of `docker-kubectl vX.Y.Z` bundling kubectl `vX.Y.Z` is preserved; no new release tag was cut for this image-only change.
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image.
 
 ## [1.36.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [1.37.0] - 2026-05-10
-
 ### Changed
 
-- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. Required so init containers and jobs that pull this image can run on Graviton/arm64 nodes without `exec format error`. The `kubectl` binary is now downloaded from `linux/${TARGETARCH}/kubectl` based on the build platform.
+- Build and publish a multi-arch (linux/amd64 + linux/arm64) container image. The `v1.36.0` registry tag was rebuilt in-place to include both architectures (kubectl version unchanged), so existing consumers pinning `1.36.0` automatically get arm64 support on next pull. The convention of `docker-kubectl vX.Y.Z` bundling kubectl `vX.Y.Z` is preserved; no new release tag was cut for this image-only change.
 
 ## [1.36.0] - 2026-04-29
 
@@ -347,8 +345,7 @@ This is a re-release of tag 1.24.1 from 2022-05-29 to include jq
 
 - Add `kubectl` version `1.18.2` .
 
-[Unreleased]: https://github.com/giantswarm/docker-kubectl/compare/v1.37.0...HEAD
-[1.37.0]: https://github.com/giantswarm/docker-kubectl/compare/v1.36.0...v1.37.0
+[Unreleased]: https://github.com/giantswarm/docker-kubectl/compare/v1.36.0...HEAD
 [1.36.0]: https://github.com/giantswarm/docker-kubectl/compare/v1.35.4...v1.36.0
 [1.35.4]: https://github.com/giantswarm/docker-kubectl/compare/v1.34.4...v1.35.4
 [1.34.4]: https://github.com/giantswarm/docker-kubectl/compare/v1.33.4...v1.34.4


### PR DESCRIPTION
Follow-up to #121 / #122.

The release bot in #122 cut a `v1.37.0` tag for the multi-arch change. That violates this repo's version convention (`docker-kubectl vX.Y.Z` bundles kubectl `vX.Y.Z`) — kubectl `v1.37.0` doesn't exist yet (latest is `v1.36.0`), so the tag was misleading.

Decision: don't introduce a new docker-kubectl version for an image-only change. Instead, rebuild the existing `v1.36.0` registry tag in-place to include both `linux/amd64` and `linux/arm64`. Existing consumers pinning `1.36.0` automatically get arm64 support on next pull. The convention is preserved.

Done before merging this PR:

- [x] Deleted GitHub release `v1.37.0`
- [x] Deleted git tag `v1.37.0`

This PR:

- Revert the `[1.37.0]` CHANGELOG section (it never shipped)
- Move the multi-arch entry under `[Unreleased]` with a note explaining the in-place rebuild
- Fix the `[Unreleased]` compare link to target `v1.36.0`

Still required (separate, manual):

- [ ] Manually rebuild and push `gsoci.azurecr.io/giantswarm/docker-kubectl:1.36.0` as multi-arch (`docker buildx build --platform linux/amd64,linux/arm64 ...`)
- [ ] Delete the orphan `gsoci.azurecr.io/giantswarm/docker-kubectl:1.37.0` image from the registry
